### PR TITLE
Updated perlin noise value range.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,5 @@ You may use the script (Perlin.cs) in your projects freely.
 Tips
 ----
 
-The value range of the noise functions is [-1.0, +1.0].
-
-AFAIK, the value range of the fBm functions is not well-defined. It might be
-somewhere around [-0.75, +0.75]. Please let me know if you have the exact
-solution :wink:
+The value range of the noise functions is [-sqrt(n)/2, sqrt(n)/2] where n is the number of dimensions.
+For instance 1D Perlin Noise has value range of [-0.5, 0.5]


### PR DESCRIPTION
You can verify by yourself just try generating noise value keeping track of the max and the min values it spits out. You'll see:
1D: [-0.5, 0.5]
2D: [-1/sqrt(2), 1/sqrt(2)] ~= [-0.707, 0,707] 
3D: [-sqrt(3)/2, -sqrt(3)/2] ~= [-0.866, 0.866]
[Here a nice explaination](http://digitalfreepen.com/2017/06/20/range-perlin-noise.html)